### PR TITLE
WIP: Removed public udef from Sims

### DIFF
--- a/src/mdsynthesis/tests/test_filesystem.py
+++ b/src/mdsynthesis/tests/test_filesystem.py
@@ -28,8 +28,8 @@ class TestUniversehound:
             py.path.local(GRO).copy(GRO_t)
             py.path.local(XTC).copy(XTC_t)
 
-            s.udef.topology = GRO_t.strpath
-            s.udef.trajectory = XTC_t.strpath
+            u = MDAnalysis.Universe(GRO_t.strpath, XTC_t.strpath)
+            s.universe = u
         return s
 
     @pytest.fixture
@@ -45,8 +45,8 @@ class TestUniversehound:
             py.path.local(GRO).copy(GRO_t)
             py.path.local(XTC).copy(XTC_t)
 
-            s.udef.topology = GRO_t.strpath
-            s.udef.trajectory = XTC_t.strpath
+            u = MDAnalysis.Universe(GRO_t.strpath, XTC_t.strpath)
+            s.universe = u
         return s
 
     def test_move_Sim_external(self, sim_external, tmpdir):
@@ -57,16 +57,16 @@ class TestUniversehound:
         assert isinstance(sim_external.universe, MDAnalysis.Universe)
 
         sim = sim_external
-        assert sim.universe.filename == sim.udef.topology
-        assert sim.universe.trajectory.filename == sim.udef.trajectory
+        assert sim.universe.filename == sim._udef.topology
+        assert sim.universe.trajectory.filename == sim._udef.trajectory
 
     def test_move_Sim_internal(self, sim_internal, tmpdir):
         sim_internal.location = tmpdir.mkdir('test').strpath
         assert isinstance(sim_internal.universe, MDAnalysis.Universe)
 
         sim = sim_internal
-        assert sim.universe.filename == sim.udef.topology
-        assert sim.universe.trajectory.filename == sim.udef.trajectory
+        assert sim.universe.filename == sim._udef.topology
+        assert sim.universe.trajectory.filename == sim._udef.trajectory
 
     def test_move_Sim_internal_copy(self, sim_internal, tmpdir):
         """We move the whole Sim, including its internal trajectory files, and
@@ -74,11 +74,11 @@ class TestUniversehound:
         be.
         """
         grofile = tmpdir.join(sim_internal.name, 'sub', self.GRO)
-        assert sim_internal.udef.topology == grofile.strpath
+        assert sim_internal._udef.topology == grofile.strpath
 
         sim_internal.location = tmpdir.mkdir('test').strpath
         tmpdir.join('test', sim_internal.name, 'sub', self.GRO).copy(
                 tmpdir.mkdir(sim_internal.name).mkdir('sub'))
 
         with pytest.raises(IOError):
-            sim_internal.universe
+            assert isinstance(sim_internal.universe, MDAnalysis.Universe)

--- a/src/mdsynthesis/tests/test_treants.py
+++ b/src/mdsynthesis/tests/test_treants.py
@@ -33,16 +33,6 @@ class TestSim(TestTreant):
     class TestUniverse:
         """Test universe functionality"""
 
-        def test_add_universe(self, treant):
-            """Test adding a new unverse definition"""
-            treant.udef.topology = GRO
-            treant.udef.trajectory = XTC
-
-            assert isinstance(treant.universe, mda.Universe)
-
-            assert treant.universe.filename == GRO
-            assert treant.universe.trajectory.filename == XTC
-
         def test_set_universe(self, treant):
             """Test setting the universe with a Universe object"""
 
@@ -52,8 +42,8 @@ class TestSim(TestTreant):
             treant.universe = u
 
             assert isinstance(treant.universe, mda.Universe)
-            assert treant.udef.topology == GRO
-            assert treant.udef.trajectory == XTC
+            assert treant.universe.filename == GRO
+            assert treant.universe.trajectory.filename == XTC
 
         def test_add_univese_typeerror(self, treant):
             """Test checking of what is passed to setter"""
@@ -62,34 +52,37 @@ class TestSim(TestTreant):
 
         def test_remove_universe(self, treant):
             """Test universe removal"""
-            treant.udef.topology = GRO
-            treant.udef.trajectory = XTC
+            u = mda.Universe(GRO, XTC)
+
+            treant.universe = u
 
             assert isinstance(treant.universe, mda.Universe)
+            assert treant.universe.filename == GRO
+            assert treant.universe.trajectory.filename == XTC
 
-            treant.udef.topology = None
-            assert treant.udef.topology is None
+            del treant.universe
+
             assert treant.universe is None
 
             # trajectory definition should still be there
-            assert treant.udef.trajectory
+            assert treant._udef.trajectory
 
             # this should give us a universe again
-            treant.udef.topology = PDB
+            treant._udef.topology = PDB
 
             assert isinstance(treant.universe, mda.Universe)
 
             # removing trajectories should keep universe, but with PDB as
             # coordinates
-            treant.udef.trajectory = None
+            treant._udef.trajectory = None
 
             assert isinstance(treant.universe, mda.Universe)
             assert treant.universe.trajectory.n_frames == 1
 
         def test_set_resnums(self, treant):
             """Test that we can add resnums to a universe."""
-            treant.udef.topology = GRO
-            treant.udef.trajectory = XTC
+            u = mda.Universe(GRO, XTC)
+            treant.universe = u
 
             protein = treant.universe.select_atoms('protein')
             resids = protein.residues.resids
@@ -119,9 +112,8 @@ class TestSim(TestTreant):
         def treant(self, tmpdir):
             with tmpdir.as_cwd():
                 s = mds.Sim(TestSim.treantname)
-
-                s.udef.topology = GRO
-                s.udef.trajectory = XTC
+                u = mda.Universe(GRO, XTC)
+                s.universe = u
             return s
 
         def test_add_selection(self, treant):
@@ -237,8 +229,8 @@ class TestReadOnly:
             py.path.local(GRO).copy(GRO_t)
             py.path.local(XTC).copy(XTC_t)
 
-            c.udef.topology = GRO_t.strpath
-            c.udef.trajectory = XTC_t.strpath
+            u = mda.Universe(GRO_t.strpath, XTC_t.strpath)
+            c.universe = u
 
             py.path.local(c.abspath).chmod(0550, rec=True)
 

--- a/src/mdsynthesis/tests/test_treants.py
+++ b/src/mdsynthesis/tests/test_treants.py
@@ -88,9 +88,9 @@ class TestSim(TestTreant):
             resids = protein.residues.resids
             protein.residues.set_resnum(resids + 3)
 
-            treant.udef._set_resnums(treant.universe.residues.resnums)
+            treant._udef._set_resnums(treant.universe.residues.resnums)
 
-            treant.udef.reload()
+            treant._udef.reload()
 
             protein = treant.universe.select_atoms('protein')
             assert (resids + 3 == protein.residues.resnums).all()
@@ -99,9 +99,9 @@ class TestSim(TestTreant):
             protein.residues.set_resnum(resids + 6)
 
             assert (protein.residues.resnums == resids + 6).all()
-            treant.udef._set_resnums(treant.universe.residues.resnums)
+            treant._udef._set_resnums(treant.universe.residues.resnums)
 
-            treant.udef.reload()
+            treant._udef.reload()
 
             protein = treant.universe.select_atoms('protein')
             assert (resids + 6 == protein.residues.resnums).all()

--- a/src/mdsynthesis/treants.py
+++ b/src/mdsynthesis/treants.py
@@ -54,7 +54,7 @@ class Sim(Treant):
                                   categories=categories,
                                   tags=tags)
 
-        self._udef = None
+        self._udef = limbs.UniverseDefinition(self)
         self._atomselections = None
         self._universe = None     # universe 'dock'
 
@@ -80,7 +80,7 @@ class Sim(Treant):
         if self._universe:
             return self._universe
         else:
-            self.udef._activate()
+            self._udef._activate()
             return self._universe
 
     @universe.setter
@@ -89,7 +89,7 @@ class Sim(Treant):
             raise TypeError("Cannot set to {}; must be Universe".format(
                                 type(universe)))
 
-        self.udef.topology = universe.filename
+        self._udef.topology = universe.filename
         try:
             traj = universe.trajectory.filename
         except AttributeError:
@@ -98,22 +98,15 @@ class Sim(Treant):
             except AttributeError:
                 traj = None
 
-        self.udef.trajectory = traj
+        self._udef.trajectory = traj
 
         # finally, just use this instance
         self._universe = universe
 
-    @property
-    def udef(self):
-        """The universe definition for this Sim.
-
-        """
-        # attach universe if not attached, and only give results if a
-        # universe is present thereafter
-        if not self._udef:
-            self._udef = limbs.UniverseDefinition(self)
-
-        return self._udef
+    @universe.deleter
+    def universe(self):
+        self._udef.topology = None
+        self._udef.trajectory = None
 
     @property
     def atomselections(self):


### PR DESCRIPTION
So I had a go at removing `udef` from being public.  

I get two failures:
 - test_move_Sim_internal_copy - I don't know what this test is doing?
 - test_remove_universe - This is doing a cute trick with changing the topology of a Universe and using the same trajectory.  Deleting the Universe now removes both topology and trajectory

@dotsdl is this what you were thinking of?