### PR TITLE
Sim stores universe kwargs if possible; refactored atomselections to address confusing API

### DIFF
--- a/src/mdsynthesis/limbs.py
+++ b/src/mdsynthesis/limbs.py
@@ -29,7 +29,7 @@ class UniverseDefinition(Limb):
     this universe directly available via ``Sim.atomselections``.
 
     """
-    _name = '_udef'
+    _name = 'udef'
     _filepaths = ['abs', 'rel']
 
     def __init__(self, treant):

--- a/src/mdsynthesis/limbs.py
+++ b/src/mdsynthesis/limbs.py
@@ -29,7 +29,7 @@ class UniverseDefinition(Limb):
     this universe directly available via ``Sim.atomselections``.
 
     """
-    _name = 'udef'
+    _name = '_udef'
     _filepaths = ['abs', 'rel']
 
     def __init__(self, treant):
@@ -294,6 +294,14 @@ class UniverseDefinition(Limb):
     def kwargs(self, kwargs):
         if not isinstance(kwargs, dict):
             raise TypeError("Must be a dictionary")
+
+        # check that values are serializable
+        for key, value in kwargs.items():
+            if not (isinstance(value, (string_types, bool, int, float)) or
+                    value is None):
+                raise ValueError("Cannot store keyword '{}' for Universe; "
+                                 "value must be a string, bool, int, float, "
+                                 "or None, not '{}'".format(key, type(value)))
 
         with self._treant._write:
             simdict = self._treant._state['mdsynthesis']['udef']

--- a/src/mdsynthesis/tests/test_filesystem.py
+++ b/src/mdsynthesis/tests/test_filesystem.py
@@ -28,8 +28,8 @@ class TestUniversehound:
             py.path.local(GRO).copy(GRO_t)
             py.path.local(XTC).copy(XTC_t)
 
-            s.udef.topology = GRO_t.strpath
-            s.udef.trajectory = XTC_t.strpath
+            s.universedef.topology = GRO_t.strpath
+            s.universedef.trajectory = XTC_t.strpath
         return s
 
     @pytest.fixture
@@ -45,8 +45,8 @@ class TestUniversehound:
             py.path.local(GRO).copy(GRO_t)
             py.path.local(XTC).copy(XTC_t)
 
-            s.udef.topology = GRO_t.strpath
-            s.udef.trajectory = XTC_t.strpath
+            s.universedef.topology = GRO_t.strpath
+            s.universedef.trajectory = XTC_t.strpath
         return s
 
     def test_move_Sim_external(self, sim_external, tmpdir):
@@ -57,16 +57,16 @@ class TestUniversehound:
         assert isinstance(sim_external.universe, MDAnalysis.Universe)
 
         sim = sim_external
-        assert sim.universe.filename == sim.udef.topology
-        assert sim.universe.trajectory.filename == sim.udef.trajectory
+        assert sim.universe.filename == sim.universedef.topology
+        assert sim.universe.trajectory.filename == sim.universedef.trajectory
 
     def test_move_Sim_internal(self, sim_internal, tmpdir):
         sim_internal.location = tmpdir.mkdir('test').strpath
         assert isinstance(sim_internal.universe, MDAnalysis.Universe)
 
         sim = sim_internal
-        assert sim.universe.filename == sim.udef.topology
-        assert sim.universe.trajectory.filename == sim.udef.trajectory
+        assert sim.universe.filename == sim.universedef.topology
+        assert sim.universe.trajectory.filename == sim.universedef.trajectory
 
     def test_move_Sim_internal_copy(self, sim_internal, tmpdir):
         """We move the whole Sim, including its internal trajectory files, and
@@ -74,7 +74,7 @@ class TestUniversehound:
         be.
         """
         grofile = tmpdir.join(sim_internal.name, 'sub', self.GRO)
-        assert sim_internal.udef.topology == grofile.strpath
+        assert sim_internal.universedef.topology == grofile.strpath
 
         sim_internal.location = tmpdir.mkdir('test').strpath
         tmpdir.join('test', sim_internal.name, 'sub', self.GRO).copy(

--- a/src/mdsynthesis/tests/test_treants.py
+++ b/src/mdsynthesis/tests/test_treants.py
@@ -83,11 +83,24 @@ class TestSim(TestTreant):
             the Universe in the first place.
 
             """
+            # try out a basic, but nonexistent, kwarg
             u = mda.Universe(PDB, XTC, something_fake=True)
 
             treant.universe = u
-
             assert treant.udef.kwargs['something_fake'] is True
+
+            # try a kwarg with a value that won't be serializable
+            u2 = mda.Universe(PDB, XTC,
+                              something_else=mda.topology.GROParser.GROParser)
+
+            with pytest.raises(ValueError):
+                treant.universe = u2
+
+            # check that we get a warning if a Universe didn't store its kwargs
+            u3 = mda.Universe(PDB, XTC, something_fake=True)
+            del u3._kwargs
+            with pytest.warns(UserWarning):
+                treant.universe = u3
 
         def test_add_univese_typeerror(self, treant):
             """Test checking of what is passed to setter"""

--- a/src/mdsynthesis/tests/test_treants.py
+++ b/src/mdsynthesis/tests/test_treants.py
@@ -9,6 +9,8 @@ import pytest
 import os
 import shutil
 import py
+from pkg_resources import parse_version
+
 from datreant.core.tests.test_treants import TestTreant
 
 import MDAnalysis as mda
@@ -35,8 +37,8 @@ class TestSim(TestTreant):
 
         def test_add_universe(self, treant):
             """Test adding a new unverse definition"""
-            treant.udef.topology = GRO
-            treant.udef.trajectory = XTC
+            treant.universedef.topology = GRO
+            treant.universedef.trajectory = XTC
 
             assert isinstance(treant.universe, mda.Universe)
 
@@ -52,8 +54,8 @@ class TestSim(TestTreant):
             treant.universe = u
 
             assert isinstance(treant.universe, mda.Universe)
-            assert treant.udef.topology == GRO
-            assert treant.udef.trajectory == XTC
+            assert treant.universedef.topology == GRO
+            assert treant.universedef.trajectory == XTC
 
         def test_set_universe_only_topology(self, treant):
             """Test setting the Universe to a topology-only universe"""
@@ -62,18 +64,21 @@ class TestSim(TestTreant):
             treant.universe = u
 
             assert treant.universe.filename == PSF
-            assert treant.udef.topology == PSF
-            assert treant.udef.trajectory is None
+            assert treant.universedef.topology == PSF
+            assert treant.universedef.trajectory is None
 
         def test_set_universe_chainreader(self, treant):
             """Test setting the Universe to multiple file trajectory (chain)"""
-            u = mda.Universe(GRO, [XTC, XTC])
+            u = mda.Universe(GRO, (XTC, XTC))
 
             treant.universe = u
 
-            assert treant.udef.topology == GRO
-            assert treant.udef.trajectory == [XTC, XTC]
+            assert treant.universedef.topology == GRO
+            assert treant.universedef.trajectory == (XTC, XTC)
 
+        @pytest.mark.skipif((parse_version(mda.__version__) <
+                            parse_version('0.15.0')),
+                            reason="requires MDAnalysis >= 0.15.0")
         def test_set_universe_with_kwargs(self, treant):
             """Universe should preserve its kwargs, if possible.
 
@@ -87,7 +92,7 @@ class TestSim(TestTreant):
             u = mda.Universe(PDB, XTC, something_fake=True)
 
             treant.universe = u
-            assert treant.udef.kwargs['something_fake'] is True
+            assert treant.universedef.kwargs['something_fake'] is True
 
             # try a kwarg with a value that won't be serializable
             u2 = mda.Universe(PDB, XTC,
@@ -109,42 +114,42 @@ class TestSim(TestTreant):
 
         def test_remove_universe(self, treant):
             """Test universe removal"""
-            treant.udef.topology = GRO
-            treant.udef.trajectory = XTC
+            treant.universedef.topology = GRO
+            treant.universedef.trajectory = XTC
 
             assert isinstance(treant.universe, mda.Universe)
 
-            treant.udef.topology = None
-            assert treant.udef.topology is None
+            treant.universedef.topology = None
+            assert treant.universedef.topology is None
             assert treant.universe is None
 
             # trajectory definition should still be there
-            assert treant.udef.trajectory
+            assert treant.universedef.trajectory
 
             # this should give us a universe again
-            treant.udef.topology = PDB
+            treant.universedef.topology = PDB
 
             assert isinstance(treant.universe, mda.Universe)
 
             # removing trajectories should keep universe, but with PDB as
             # coordinates
-            treant.udef.trajectory = None
+            treant.universedef.trajectory = None
 
             assert isinstance(treant.universe, mda.Universe)
             assert treant.universe.trajectory.n_frames == 1
 
         def test_set_resnums(self, treant):
             """Test that we can add resnums to a universe."""
-            treant.udef.topology = GRO
-            treant.udef.trajectory = XTC
+            treant.universedef.topology = GRO
+            treant.universedef.trajectory = XTC
 
             protein = treant.universe.select_atoms('protein')
             resids = protein.residues.resids
             protein.residues.set_resnum(resids + 3)
 
-            treant.udef._set_resnums(treant.universe.residues.resnums)
+            treant.universedef._set_resnums(treant.universe.residues.resnums)
 
-            treant.udef.reload()
+            treant.universedef.reload()
 
             protein = treant.universe.select_atoms('protein')
             assert (resids + 3 == protein.residues.resnums).all()
@@ -153,9 +158,9 @@ class TestSim(TestTreant):
             protein.residues.set_resnum(resids + 6)
 
             assert (protein.residues.resnums == resids + 6).all()
-            treant.udef._set_resnums(treant.universe.residues.resnums)
+            treant.universedef._set_resnums(treant.universe.residues.resnums)
 
-            treant.udef.reload()
+            treant.universedef.reload()
 
             protein = treant.universe.select_atoms('protein')
             assert (resids + 6 == protein.residues.resnums).all()
@@ -167,8 +172,8 @@ class TestSim(TestTreant):
             with tmpdir.as_cwd():
                 s = mds.Sim(TestSim.treantname)
 
-                s.udef.topology = GRO
-                s.udef.trajectory = XTC
+                s.universedef.topology = GRO
+                s.universedef.trajectory = XTC
             return s
 
         def test_add_selection(self, treant):
@@ -180,9 +185,10 @@ class TestSim(TestTreant):
             CA = treant.universe.select_atoms('protein and name CA')
             someres = treant.universe.select_atoms('resid 12')
 
-            assert (CA.indices == treant.atomselections['CA'].indices).all()
+            assert (CA.indices ==
+                    treant.atomselections.create('CA').indices).all()
             assert (someres.indices ==
-                    treant.atomselections['someres'].indices).all()
+                    treant.atomselections.create('someres').indices).all()
 
         def test_remove_selection(self, treant):
             """Test universe removal"""
@@ -217,13 +223,14 @@ class TestSim(TestTreant):
 
             assert set(('CA', 'someres')) == set(treant.atomselections.keys())
 
-        def test_selection_define(self, treant):
+        def test_selection_get(self, treant):
             CA = 'protein and name CA'
             treant.atomselections.add('CA', CA)
 
-            assert treant.atomselections.define('CA')[0] == CA
+            assert treant.atomselections.get('CA') == CA
+            assert treant.atomselections['CA'] == CA
 
-        def test_selection_get(self, treant):
+        def test_selection_get_not_present(self, treant):
             with pytest.raises(KeyError):
                 treant.atomselections['CA']
 
@@ -233,7 +240,7 @@ class TestSim(TestTreant):
             assert 'funky town' in treant.atomselections
 
             ref = treant.universe.select_atoms('name N', 'name CA')
-            sel = treant.atomselections['funky town']
+            sel = treant.atomselections.create('funky town')
             assert (ref.indices == sel.indices).all()
 
         def test_add_atomselections_multiple_strings_via_setitem(self, treant):
@@ -242,28 +249,56 @@ class TestSim(TestTreant):
             assert 'funky town 2' in treant.atomselections
 
             ref = treant.universe.select_atoms('name N', 'name CA')
-            sel = treant.atomselections['funky town 2']
+            sel = treant.atomselections.create('funky town 2')
             assert (ref.indices == sel.indices).all()
 
-        def test_add_selection_as_atomgroup_via_add(self, treant):
+        def test_add_selection_as_indices_via_add(self, treant):
             """Make an arbitrary AtomGroup then save selection as AG"""
             ag = treant.universe.atoms[:10:2]
 
-            treant.atomselections.add('ag sel', ag)
+            treant.atomselections.add('ag sel', ag.indices)
             assert 'ag sel' in treant.atomselections
 
-            ag2 = treant.atomselections['ag sel']
+            ag2 = treant.atomselections.create('ag sel')
             assert (ag.indices == ag2.indices).all()
 
-        def test_add_selection_as_atomgroup_via_setitem(self, treant):
+        def test_add_selection_as_indices_via_setitem(self, treant):
             """Make an arbitrary AtomGroup then save selection as AG"""
             ag = treant.universe.atoms[25:50:3]
 
-            treant.atomselections['ag sel 2'] = ag
+            treant.atomselections['ag sel 2'] = ag.indices
             assert 'ag sel 2' in treant.atomselections
 
-            ag2 = treant.atomselections['ag sel 2']
+            ag2 = treant.atomselections.create('ag sel 2')
             assert (ag.indices == ag2.indices).all()
+
+        def test_add_selection_as_mix_via_setitem(self, treant):
+            """Save a selection as a mixture of atom indices and strings"""
+            ag = treant.universe.atoms[25:50:3]
+
+            treant.atomselections['ag sel 2'] = ('protein and name CA',
+                                                 ag.indices)
+
+            assert 'ag sel 2' in treant.atomselections
+
+            ag2 = treant.atomselections.create('ag sel 2')
+
+            ag3 = treant.universe.select_atoms('protein and name CA') + ag
+            assert (ag2.indices == ag3.indices).all()
+
+        def test_add_selection_as_mix_via_add(self, treant):
+            """Save a selection as a mixture of atom indices and strings"""
+            ag = treant.universe.atoms[25:50:3]
+
+            treant.atomselections.add('ag sel 2', 'protein and name CA',
+                                      ag.indices)
+
+            assert 'ag sel 2' in treant.atomselections
+
+            ag2 = treant.atomselections.create('ag sel 2')
+
+            ag3 = treant.universe.select_atoms('protein and name CA') + ag
+            assert (ag2.indices == ag3.indices).all()
 
 
 class TestReadOnly:
@@ -284,8 +319,8 @@ class TestReadOnly:
             py.path.local(GRO).copy(GRO_t)
             py.path.local(XTC).copy(XTC_t)
 
-            c.udef.topology = GRO_t.strpath
-            c.udef.trajectory = XTC_t.strpath
+            c.universedef.topology = GRO_t.strpath
+            c.universedef.trajectory = XTC_t.strpath
 
             py.path.local(c.abspath).chmod(0550, rec=True)
 

--- a/src/mdsynthesis/tests/test_treants.py
+++ b/src/mdsynthesis/tests/test_treants.py
@@ -74,6 +74,21 @@ class TestSim(TestTreant):
             assert treant.udef.topology == GRO
             assert treant.udef.trajectory == [XTC, XTC]
 
+        def test_set_universe_with_kwargs(self, treant):
+            """Universe should preserve its kwargs, if possible.
+
+            Test that setting a Universe for a Sim also gets its kwargs
+            preserved, that an exception is raised for unserializable kwargs,
+            and that a proper warning is geven when the Sim can't get them from
+            the Universe in the first place.
+
+            """
+            u = mda.Universe(PDB, XTC, something_fake=True)
+
+            treant.universe = u
+
+            assert treant.udef.kwargs['something_fake'] is True
+
         def test_add_univese_typeerror(self, treant):
             """Test checking of what is passed to setter"""
             with pytest.raises(TypeError):

--- a/src/mdsynthesis/treants.py
+++ b/src/mdsynthesis/treants.py
@@ -54,7 +54,7 @@ class Sim(Treant):
                                   categories=categories,
                                   tags=tags)
 
-        self._udef = None
+        self._udef = limbs.UniverseDefinition(self)
         self._atomselections = None
         self._universe = None     # universe 'dock'
 
@@ -80,7 +80,7 @@ class Sim(Treant):
         if self._universe:
             return self._universe
         else:
-            self.udef._activate()
+            self._udef._activate()
             return self._universe
 
     @universe.setter
@@ -89,7 +89,7 @@ class Sim(Treant):
             raise TypeError("Cannot set to {}; must be Universe".format(
                                 type(universe)))
 
-        self.udef.topology = universe.filename
+        self._udef.topology = universe.filename
         try:
             traj = universe.trajectory.filename
         except AttributeError:
@@ -98,22 +98,12 @@ class Sim(Treant):
             except AttributeError:
                 traj = None
 
-        self.udef.trajectory = traj
+        self._udef.trajectory = traj
+
+        self._udef.kwargs = universe._kwargs
 
         # finally, just use this instance
         self._universe = universe
-
-    @property
-    def udef(self):
-        """The universe definition for this Sim.
-
-        """
-        # attach universe if not attached, and only give results if a
-        # universe is present thereafter
-        if not self._udef:
-            self._udef = limbs.UniverseDefinition(self)
-
-        return self._udef
 
     @property
     def atomselections(self):

--- a/src/mdsynthesis/treants.py
+++ b/src/mdsynthesis/treants.py
@@ -54,7 +54,7 @@ class Sim(Treant):
                                   categories=categories,
                                   tags=tags)
 
-        self._udef = limbs.UniverseDefinition(self)
+        self._udef = None
         self._atomselections = None
         self._universe = None     # universe 'dock'
 
@@ -80,7 +80,7 @@ class Sim(Treant):
         if self._universe:
             return self._universe
         else:
-            self._udef._activate()
+            self.udef._activate()
             return self._universe
 
     @universe.setter
@@ -89,7 +89,7 @@ class Sim(Treant):
             raise TypeError("Cannot set to {}; must be Universe".format(
                                 type(universe)))
 
-        self._udef.topology = universe.filename
+        self.udef.topology = universe.filename
         try:
             traj = universe.trajectory.filename
         except AttributeError:
@@ -98,12 +98,29 @@ class Sim(Treant):
             except AttributeError:
                 traj = None
 
-        self._udef.trajectory = traj
+        self.udef.trajectory = traj
 
-        self._udef.kwargs = universe._kwargs
+        # try and store keyword arguments
+        try:
+            self.udef.kwargs = universe._kwargs
+        except AttributeError:
+            warnings.warn("Could not store universe keyword arguments; "
+                          "manually set these with ``Sim.udef.kwargs``")
 
         # finally, just use this instance
         self._universe = universe
+
+    @property
+    def udef(self):
+        """The universe definition for this Sim.
+
+        """
+        # attach universe if not attached, and only give results if a
+        # universe is present thereafter
+        if not self._udef:
+            self._udef = limbs.UniverseDefinition(self)
+
+        return self._udef
 
     @property
     def atomselections(self):

--- a/src/mdsynthesis/treants.py
+++ b/src/mdsynthesis/treants.py
@@ -108,8 +108,8 @@ class Sim(Treant):
             try:
                 self.udef.kwargs = universe._kwargs
             except AttributeError:
-                warnings.warn("Could not store universe keyword arguments; "
-                              "manually set these with ``Sim.udef.kwargs``")
+                warnings.warn("Universe did not keep keyword arguments; "
+                              "cannot store keyword arguments for Universe.")
 
             # finally, just use this instance
             self._universe = universe


### PR DESCRIPTION
Addresses concerns in #48 and #54. Fixes #25 pending upstream mdanalysis/MDAnalysis#813.

We will encourage setting a Sim universe directly with an existing Universe, with the hope that we can eventually hide UniverseDefinition. At the moment, though, we leave it exposed for any manual interventions that can't be handled from the Universe itself.

Also, AtomSelection getitem no longer returns an AtomGroup, but instead gives back the definition of the selection (that which was stored). It is possible to store only strings or numpy arrays of atom indices,
or tuples/lists of these in any combination. One cannot directly store AtomGroups, but can store atom indices with `AG.indices`.

Getting back an AtomGroup from the stored definition requires using the `create` method. This makes it clear that a new AtomGroup is being generated, and that there is a cost to this.