### PR TITLE
update conda build recipe

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -1,9 +1,12 @@
 package:
   name: mdsynthesis
-  version: "0.6.0"
+  version: "0.6.1"
 
 source:
-    path: .
+   # path: .
+   git_url: https://github.com/datreant/MDSynthesis
+   # git_branch: master
+   git_tag: 0.6.1
 
 build:
     noarch_python: True


### PR DESCRIPTION
update to new release. Package is already updated.
# Conda Publish Instructions
1. change `version` string ang `git_tag` to current release
2. run `conda build .` in the root directory
3. run `anaconda upload -u datreant /path/to/package/that/conda/tells/you`
