### PR TITLE
Update mda dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from setuptools import setup, find_packages
 setup(name='mdsynthesis',
       version='0.6.2-dev',
       description='a persistence engine for molecular dynamics data',
-      author='David Dotson', 
+      author='David Dotson',
       author_email='dotsdl@gmail.com',
       url='http://mdsynthesis.readthedocs.org/',
       classifiers=[
@@ -34,4 +34,4 @@ setup(name='mdsynthesis',
                 'datreant.data>=0.6.0',
                 'MDAnalysis>=0.14.0',
                 ],
-     )
+      )

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(name='mdsynthesis',
       install_requires=[
                 'datreant.core>=0.6.0',
                 'datreant.data>=0.6.0',
+                # TODO: update dependency to 0.16.0 once it's released
                 'MDAnalysis>=0.14.0',
                 ],
       )

--- a/src/mdsynthesis/filesystem.py
+++ b/src/mdsynthesis/filesystem.py
@@ -3,9 +3,6 @@ Functions and classes for finding Treants in the filesystem.
 
 """
 import os
-import glob
-
-from datreant.core import Treant, Group
 
 
 class Universehound(object):

--- a/src/mdsynthesis/limbs.py
+++ b/src/mdsynthesis/limbs.py
@@ -17,7 +17,6 @@ import warnings
 from datreant.core import Leaf
 from datreant.core.limbs import Limb
 from MDAnalysis import Universe
-from MDAnalysis.core.AtomGroup import AtomGroup
 
 from .filesystem import Universehound
 

--- a/src/mdsynthesis/limbs.py
+++ b/src/mdsynthesis/limbs.py
@@ -406,7 +406,7 @@ class AtomSelections(Limb):
             if isinstance(sel, np.ndarray):
                 outsel = sel.tolist()
             elif isinstance(sel, string_types):
-                    outsel = sel
+                outsel = sel
         else:
             outsel = list()
             for sel in selection:

--- a/src/mdsynthesis/limbs.py
+++ b/src/mdsynthesis/limbs.py
@@ -215,7 +215,11 @@ class UniverseDefinition(Limb):
                 resnums = None
 
         if resnums:
-            self._treant._universe.residues.resnums = resnums
+            # Compatibility for MDAnalysis pre 0.16.0
+            try:
+                self._treant._universe.residues.resnums = resnums
+            except AttributeError:
+                self._treant._universe.residues.set_resnum(resnums)
 
     @deprecate(message="resnum storage is deprecated")
     def _set_resnums(self, resnums):

--- a/src/mdsynthesis/limbs.py
+++ b/src/mdsynthesis/limbs.py
@@ -215,7 +215,7 @@ class UniverseDefinition(Limb):
                 resnums = None
 
         if resnums:
-            self._treant._universe.residues.set_resnums(np.array(resnums))
+            self._treant._universe.residues.resnums = resnums
 
     @deprecate(message="resnum storage is deprecated")
     def _set_resnums(self, resnums):
@@ -239,7 +239,7 @@ class UniverseDefinition(Limb):
             if resnums is None:
                 simdict['resnums'] = None
             else:
-                simdict['resnums'] = list(resnums)
+                simdict['resnums'] = np.asarray(resnums).tolist()
 
             if self._treant._universe:
                 self._apply_resnums()

--- a/src/mdsynthesis/tests/test_treants.py
+++ b/src/mdsynthesis/tests/test_treants.py
@@ -97,12 +97,6 @@ class TestSim(TestTreant):
             with pytest.raises(ValueError):
                 treant.universe = u2
 
-            # check that we get a warning if a Universe didn't store its kwargs
-            u3 = mda.Universe(PDB, XTC, something_fake=True)
-            del u3._kwargs
-            with pytest.warns(UserWarning):
-                treant.universe = u3
-
         def test_add_univese_typeerror(self, treant):
             """Test checking of what is passed to setter"""
             with pytest.raises(TypeError):

--- a/src/mdsynthesis/tests/test_treants.py
+++ b/src/mdsynthesis/tests/test_treants.py
@@ -135,7 +135,11 @@ class TestSim(TestTreant):
 
             protein = treant.universe.select_atoms('protein')
             resids = protein.residues.resids
-            protein.residues.resnums = resids + 3
+            # Compatibility for MDAnalysis pre 0.16.0
+            try:
+                protein.residues.resnums = resids + 3
+            except AttributeError:
+                protein.residues.set_resnum(resids + 3)
 
             treant.universedef._set_resnums(treant.universe.residues.resnums)
 
@@ -144,8 +148,11 @@ class TestSim(TestTreant):
             protein = treant.universe.select_atoms('protein')
             assert (resids + 3 == protein.residues.resnums).all()
 
-            # test resetting of resnums
-            protein.residues.resnums = resids + 6
+            # Compatibility for MDAnalysis pre 0.16.0
+            try:
+                protein.residues.resnums = resids + 6
+            except AttributeError:
+                protein.residues.set_resnum(resids + 6)
 
             assert (protein.residues.resnums == resids + 6).all()
             treant.universedef._set_resnums(treant.universe.residues.resnums)

--- a/src/mdsynthesis/tests/test_treants.py
+++ b/src/mdsynthesis/tests/test_treants.py
@@ -3,11 +3,7 @@
 """
 
 import mdsynthesis as mds
-import pandas as pd
-import numpy as np
 import pytest
-import os
-import shutil
 import py
 from pkg_resources import parse_version
 
@@ -322,10 +318,10 @@ class TestReadOnly:
             c.universedef.topology = GRO_t.strpath
             c.universedef.trajectory = XTC_t.strpath
 
-            py.path.local(c.abspath).chmod(0550, rec=True)
+            py.path.local(c.abspath).chmod(0o0550, rec=True)
 
         def fin():
-            py.path.local(c.abspath).chmod(0770, rec=True)
+            py.path.local(c.abspath).chmod(0o0770, rec=True)
 
         request.addfinalizer(fin)
 
@@ -340,13 +336,13 @@ class TestReadOnly:
         """Test that Sim can access Universe when read-only, especially
         when universe files have moved with it (stale paths).
         """
-        py.path.local(sim.abspath).chmod(0770, rec=True)
+        py.path.local(sim.abspath).chmod(0o0770, rec=True)
         sim.location = tmpdir.mkdir('test').strpath
-        py.path.local(sim.abspath).chmod(0550, rec=True)
+        py.path.local(sim.abspath).chmod(0o0550, rec=True)
 
         assert isinstance(sim.universe, mda.Universe)
 
-        py.path.local(sim.abspath).chmod(0770, rec=True)
+        py.path.local(sim.abspath).chmod(0o0770, rec=True)
 
     def test_fresh_sim_readonly(self, sim):
         """Test that a read-only Sim can be initialized without issue.
@@ -360,4 +356,4 @@ class TestReadOnly:
         # would be nice if it DIDN'T behave this way, but lazy loading keeps
         # Sim init cheaper
         with pytest.raises(KeyError):
-            len(s.atomselections) == 0
+            s.atomselections

--- a/src/mdsynthesis/tests/test_treants.py
+++ b/src/mdsynthesis/tests/test_treants.py
@@ -141,7 +141,7 @@ class TestSim(TestTreant):
 
             protein = treant.universe.select_atoms('protein')
             resids = protein.residues.resids
-            protein.residues.set_resnum(resids + 3)
+            protein.residues.resnums = resids + 3
 
             treant.universedef._set_resnums(treant.universe.residues.resnums)
 
@@ -151,7 +151,7 @@ class TestSim(TestTreant):
             assert (resids + 3 == protein.residues.resnums).all()
 
             # test resetting of resnums
-            protein.residues.set_resnum(resids + 6)
+            protein.residues.resnums = resids + 6
 
             assert (protein.residues.resnums == resids + 6).all()
             treant.universedef._set_resnums(treant.universe.residues.resnums)

--- a/src/mdsynthesis/treants.py
+++ b/src/mdsynthesis/treants.py
@@ -3,12 +3,10 @@ Basic Treant objects: the organizational units for :mod:`mdsynthesis`.
 
 """
 import warnings
-import os
-from six import string_types
 
 from MDAnalysis import Universe
 
-from datreant.core import Treant, Leaf
+from datreant.core import Treant
 from . import limbs
 from .backends import statefiles
 

--- a/src/mdsynthesis/treants.py
+++ b/src/mdsynthesis/treants.py
@@ -101,14 +101,7 @@ class Sim(Treant):
                     traj = []
 
             self.universedef._set_trajectory(traj)
-
-            # try and store keyword arguments
-            try:
-                self.universedef.kwargs = universe.kwargs
-            except AttributeError:
-                warnings.warn("Universe did not keep keyword arguments; "
-                              "cannot store keyword arguments for Universe.")
-
+            self.universedef.kwargs = universe.kwargs
             # finally, just use this instance
             self._universe = universe
 


### PR DESCRIPTION
This includes various fixes to be usable with the new MDAnalysis version. kwargs can't be stored right now because of an old bug that has reappeared in MDAnalysis. 