### PR TITLE
add build using development version of datreant

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,15 @@ branches:
         - master
         - develop
 
+env:
+  matrix:
+    - DATREANT_DEV="true"
+    - DATREANT_DEV="false"
+
+matrix:
+  allow_failures:
+    - env: DATREANT_DEV="true"
+
 # install python dependencies
 install:
   - pip install codecov
@@ -23,6 +32,10 @@ install:
   - pip install pytest-pep8
   - pip install numpy numexpr Cython
   - pip install MDAnalysisTests
+  - |
+    if [[ $DATREANT_DEV == 'true' ]]; then \
+      pip install git+https://github.com/datreant/datreant.core.git;\
+    fi
   - pip install --process-dependency-links -e .
 
 # run tests


### PR DESCRIPTION
@dotsdl this might help to test that we are compatible with the current development version of datreant. I assume the build will fail right now. I'm more interested that it runs on Travis in the first place.