### PR TITLE
Changes made to work with upstream changes in datreant

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,8 @@ setup(name='mdsynthesis',
       license='GPL 2',
       long_description=open('README.rst').read(),
       install_requires=[
-                'datreant.core>=0.6.0',
+                'datreant',
                 'MDAnalysis>=0.16.0',
-                'tables', 'numpy', 'pandas'
+                'tables', 'h5py', 'numpy', 'pandas'
                 ],
       )

--- a/src/mdsynthesis/__init__.py
+++ b/src/mdsynthesis/__init__.py
@@ -8,8 +8,8 @@ MDSynthesis --- a persistence engine for molecular dynamics data
 ================================================================
 """
 # Bring some often used objects into the current namespace
-from datreant.core import Tree, Leaf, View, Bundle
-from datreant.core import discover
+from datreant import Tree, Leaf, View, Bundle
+from datreant import discover
 
 from .treants import Sim
 from .manipulators import discover

--- a/src/mdsynthesis/data.py
+++ b/src/mdsynthesis/data.py
@@ -1,4 +1,4 @@
-from datreant.core.util import makedirs
+from datreant.util import makedirs
 from functools import wraps
 import six
 import os

--- a/src/mdsynthesis/manipulators.py
+++ b/src/mdsynthesis/manipulators.py
@@ -3,9 +3,9 @@
 """
 import os
 
-from datreant.core import discover as _discover
-from datreant.core import Bundle
-from datreant.core.names import TREANTDIR_NAME
+from datreant import discover as _discover
+from datreant import Bundle
+from datreant.names import TREANTDIR_NAME
 
 from .treants import Sim
 from .names import SIMDIR_NAME

--- a/src/mdsynthesis/metadata.py
+++ b/src/mdsynthesis/metadata.py
@@ -11,8 +11,8 @@ import numpy as np
 from numpy.lib.utils import deprecate
 import warnings
 
-from datreant.core import Leaf
-from datreant.core.metadata import Metadata
+from datreant import Leaf
+from datreant.metadata import Metadata
 import MDAnalysis as mda
 
 from .names import SIMDIR_NAME

--- a/src/mdsynthesis/persistent_dict/npdata.py
+++ b/src/mdsynthesis/persistent_dict/npdata.py
@@ -5,7 +5,7 @@ File backends for storing numpy arrays.
 
 import h5py
 
-from datreant.core.state import BaseFile as File
+from datreant.state import BaseFile as File
 
 npdatafile = 'npData.h5'
 

--- a/src/mdsynthesis/persistent_dict/pddata.py
+++ b/src/mdsynthesis/persistent_dict/pddata.py
@@ -6,7 +6,7 @@ File backends for storing pandas objects.
 import pandas as pd
 import numpy as np
 
-from datreant.core.state import BaseFile as File
+from datreant.state import BaseFile as File
 
 pddatafile = 'pdData.h5'
 

--- a/src/mdsynthesis/persistent_dict/pydata.py
+++ b/src/mdsynthesis/persistent_dict/pydata.py
@@ -5,7 +5,7 @@ File backends for storing general python objects.
 
 from six.moves import cPickle as pickle
 
-from datreant.core.state import BaseFile as File
+from datreant.state import BaseFile as File
 
 pydatafile = 'pyData.pkl'
 

--- a/src/mdsynthesis/tests/data.py
+++ b/src/mdsynthesis/tests/data.py
@@ -1,7 +1,7 @@
 """Data structures for storage and retrieval.
 
 """
-import datreant.core as dtr
+import datreant as dtr
 import pandas as pd
 import numpy as np
 import pytest

--- a/src/mdsynthesis/tests/test_manipulators.py
+++ b/src/mdsynthesis/tests/test_manipulators.py
@@ -1,4 +1,4 @@
-import datreant.core as dtr
+import datreant as dtr
 import mdsynthesis as mds
 
 

--- a/src/mdsynthesis/tests/test_treants.py
+++ b/src/mdsynthesis/tests/test_treants.py
@@ -7,7 +7,7 @@ import pytest
 import py
 from pkg_resources import parse_version
 
-from datreant.core.tests.test_treants import TestTreant
+from datreant.tests.test_treants import TestTreant
 
 import MDAnalysis as mda
 from MDAnalysisTests.datafiles import PDB, GRO, XTC, PSF

--- a/src/mdsynthesis/treants.py
+++ b/src/mdsynthesis/treants.py
@@ -10,9 +10,9 @@ from functools import wraps
 
 import MDAnalysis as mda
 
-from datreant.core import Treant
-from datreant.core.names import TREANTDIR_NAME
-from datreant.core.util import makedirs
+from datreant import Treant
+from datreant.names import TREANTDIR_NAME
+from datreant.util import makedirs
 from .names import SIMDIR_NAME
 from . import metadata
 from .data import Data


### PR DESCRIPTION
Although the user interface of `datreant` can still be accessed through `datreant.core`, many internal components can't be accessed in the old way. The changes made in this PR ensure that `mdsynthesis` will work just fine with `datreant` when it gets released.