### PR TITLE
allow develop builds to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
 
 matrix:
   allow_failures:
-    - env: DATREANT_DEV="false"
+    - env: DATREANT_DEV="true"
 
 # install python dependencies
 install:


### PR DESCRIPTION
since the new release the tests against stable datreant should work all
the time. Allowing the develop builds is nice to catch future changes
early.

moves towards 1.0